### PR TITLE
Fix private call

### DIFF
--- a/ib/build.gradle
+++ b/ib/build.gradle
@@ -93,7 +93,7 @@ android {
 dependencies {
     provided fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:26.+'
-    compile 'com.opentok.android:opentok-android-sdk:2.11.1+'
+    compile 'com.opentok.android:opentok-android-sdk:2.12.0'
     compile 'com.opentok.android:opentok-solutions-logging:+'
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.13'
     compile 'com.squareup.picasso:picasso:2.5.2'

--- a/ib/src/main/java/com/tokbox/android/IB/FanActivity.java
+++ b/ib/src/main/java/com/tokbox/android/IB/FanActivity.java
@@ -1387,7 +1387,7 @@ public class FanActivity extends AppCompatActivity implements WebServiceCoordina
 
     @Override
     public void onStreamDestroyed(PublisherKit publisher, Stream stream) {
-        if(publisher.getSession().getSessionId().equals(mSessionId)) {
+        if(stream.getSession().getSessionId().equals(mSessionId)) {
             addLogEvent(OTKAction.FAN_UNPUBLISHES_ONSTAGE, OTKVariation.SUCCESS);
         } else {
             addLogEvent(OTKAction.FAN_UNPUBLISHES_BACKSTAGE, OTKVariation.SUCCESS);


### PR DESCRIPTION
This PR fixes the following:
1) When the fan joins an event without the producer, and then the producer joins the event and start a private call, the android app was breaking.
2) We're now using the latest verson 2.12 and there's another fix related to onStreamDestroyed. We're now getting the session Id from the stream instead from the publisher that at this momento could be null.